### PR TITLE
Change from s3_origin to custom_origin for Cloudfront distribution

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,11 +93,14 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   ]
 
   origin {
-    domain_name = data.aws_s3_bucket.website_bucket.bucket_regional_domain_name
+    domain_name = data.aws_s3_bucket.website_bucket.website_endpoint
     origin_id   = aws_cloudfront_origin_access_identity.origin_access_identity.id
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols = ["TLSv1.2"]
     }
   }
 
@@ -191,4 +194,3 @@ data "aws_iam_policy_document" "s3_policy" {
     }
   }
 }
-


### PR DESCRIPTION
## What

Changed from `s3_origin_config` to `custom_origin_config` for the origion on the `aws_cloudfront_distribution` resource.

## Why

We are trying to set up the S3 bucket to redirect to another domain, but this didn't work while using the `s3_origin_config`. The redirect config in S3 is ignored, and Cloudfront still tries to serve the index document. 

Changing to custom origin allows us to use the `website_endpoint` of the bucket, and this fixes the behaviour. [This article](https://blog.chrisdpeters.com/full-domain-redirects-s3-and-cloudfront/#cloudfront) suggested this fix to the problem.

## Testing

Tested this for https://dt.test.trafficgui.vydev.io (pointing to driftstjenester.vy.no) [here](https://github.com/nsbno/task-frontend/pull/192/files).

Also tested this with a website without redirects, which worked as before.