### PR TITLE
Revert #1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,14 +93,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   ]
 
   origin {
-    domain_name = data.aws_s3_bucket.website_bucket.website_endpoint
+    domain_name = data.aws_s3_bucket.website_bucket.bucket_regional_domain_name
     origin_id   = aws_cloudfront_origin_access_identity.origin_access_identity.id
 
-    custom_origin_config {
-      http_port = 80
-      https_port = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols = ["TLSv1.2"]
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
     }
   }
 
@@ -194,3 +191,4 @@ data "aws_iam_policy_document" "s3_policy" {
     }
   }
 }
+


### PR DESCRIPTION
Møtte på problemer da jeg skulle ta dette i bruk for driftstjenester.vy.no (uten redirect), til tross for at det så greit ut da jeg testet det. Ruller derfor tilbake endringene i den forrige PR-en. 

_Har i stedet trukket ut [endringene som fungerte for redirects](https://github.com/nsbno/terraform-aws-multi-domain-static-site/commit/fa221e7c892de81a6a89e7e10df48e9028e2f877) og setter dette opp spesifikt i [repoet til Driftstjenester](https://github.com/nsbno/task-frontend), i stedet for å bruke enda mer tid på å få denne modulen til å støtte både vanlige nettsider og oppsett for redirects._

Beklager at det ble litt frem og tilbake her 😅