### PR TITLE
Default objects for subdirectories

### DIFF
--- a/default_index_mapper.js
+++ b/default_index_mapper.js
@@ -1,0 +1,13 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+  }
+  else if (!uri.includes('.')) {
+    request.uri += '/index.html';
+  }
+
+  return request;
+}

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "certificate_validation_timeout" {
   type        = string
   default     = "45m"
 }
+
+variable "enable_directory_index" {
+  description = "(Optional) Map URIs ending in / or without a file ending to 'index.html'"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Add an optional Cloudfront function that will append 'index.html' to URIs ending in / or is missing a file ending